### PR TITLE
Object params

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ const client = new openaq
 ```
 
 ## API:
-Methods for all endpoints have been implemented. All parameters, if any, for each endpoint are supported as a single URL encoded argument, as seen in the examples.
+Any parameters should be passed as an optional `params` object as seen in the examples.
 
 ### [.getCities(params)](https://docs.openaq.org/#api-Cities)
 - example:
@@ -21,7 +21,7 @@ cities().then(results => {
 })
 
 //with optional parameters
-cities('country=US&page=2').then(results => {
+cities({country:'US', page:2}).then(results => {
   //results here
 })
 ```
@@ -34,7 +34,7 @@ countries().then(results => {
 })
 
 //with optional parameters
-countries('limit=10&page=2').then(results => {
+countries({limit:10, page:2}).then(results => {
   //results here
 })
 ```
@@ -46,7 +46,7 @@ fetches().then(results = {
 })
 
 //with optional parameters
-fetches('limit=10&page=2').then(results => {
+fetches({limit:10, page:2}).then(results => {
   //results here
 })
 ```
@@ -59,7 +59,7 @@ latest().then(results => {
 })
 
 //with optional parameters
-latest('location=Bowling%20Green&parameter=o3').then(results => {
+latest({location:'Bowling Green', parameter:'o3'}).then(results => {
   //results here
 })
 ```
@@ -72,7 +72,7 @@ locations().then(results => {
 })
 
 //with optional parameters
-locations('location=Bowling%20Green&parameter=o3').then(results => {
+locations({location:'Bowling Green', parameter:'o3'}).then(results => {
   //results here
 })
 ```
@@ -85,7 +85,7 @@ measurements().then(results => {
 })
 
 //with optional parameters
-measurements('location=Bowling%20Green&parameter=o3').then(results => {
+measurements({location:'Bowling Green', parameter:'o3'}).then(results => {
   //results here
 })
 ```
@@ -107,11 +107,10 @@ sources().then(results => {
 })
 
 //with optional parameters
-sources('limit=10&page=2').then(results => {
+sources({limit:10, page:2}).then(results => {
   //results here
 })
 ```
 ## TODO
 - add testing
-- improved `params` handling
 - make isomorphic (commonJS and ES2015 module support)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,11 @@
 const fetch = require('isomorphic-fetch')
 
 const url = '//api.openaq.org'
+const buildQueryString = (params) => {
+    let queryString = []
+    for (var prop in params) queryString.push(encodeURIComponent(prop) + '=' + encodeURIComponent(params[prop]))
+    return queryString.join('&')
+}
 const get = (endpoint, params) => {
     if (!params) {
         return fetch(url + endpoint)
@@ -22,32 +27,34 @@ const get = (endpoint, params) => {
 
 class OpenAQ {
     cities(params) {
-        if (params) return get('/v1/cities/?' + params)
+        if (params) {
+            return get('/v1/cities/?' + buildQueryString(params))
+        }
         return get('/v1/cities/')
     }
 
     countries(params) {
-        if (params) return get('/v1/countries/?' + params)
+        if (params) return get('/v1/countries/?' + buildQueryString(params))
         return get('/v1/countries/')
     }
 
     fetches(params) {
-        if (params) return get('/v1/fetches/?' + params)
+        if (params) return get('/v1/fetches/?' + buildQueryString(params))
         return get('/v1/fetches/')      
     }
 
     latest(params) {
-        if (params) return get('/v1/latest/?' + params)
+        if (params) return get('/v1/latest/?' + buildQueryString(params))
         return get('/v1/latest/')
     }
 
     locations(params){
-        if (params) return get('/v1/locations/?' + params)
+        if (params) return get('/v1/locations/?' + buildQueryString(params))
         return get('/v1/locations/')
     }
 
     measurements(params){
-        if (params) return get('/v1/measurements/?' + params)
+        if (params) return get('/v1/measurements/?' + buildQueryString(params))
         return get('/v1/measurements/')
     }
 
@@ -56,7 +63,7 @@ class OpenAQ {
     }
 
     sources(params){
-        if (params) return get('/v1/sources/?' + params)
+        if (params) return get('/v1/sources/?' + buildQueryString(params))
         return get('/v1/sources/')
     }
 }

--- a/index.js
+++ b/index.js
@@ -27,9 +27,7 @@ const get = (endpoint, params) => {
 
 class OpenAQ {
     cities(params) {
-        if (params) {
-            return get('/v1/cities/?' + buildQueryString(params))
-        }
+        if (params) return get('/v1/cities/?' + buildQueryString(params))
         return get('/v1/cities/')
     }
 


### PR DESCRIPTION
now `params` is an object that is parsed into a query string, which is far cleaner.